### PR TITLE
Handle allocation failure in birthday list module

### DIFF
--- a/src/kernel_birthday_list_module.c
+++ b/src/kernel_birthday_list_module.c
@@ -56,6 +56,11 @@ static int __init birthdayList_init(void) {
         birthday *person = kmalloc(sizeof(*person), GFP_KERNEL); // Allocate memory
         if (!person) {
             printk(KERN_ERR "Memory allocation for birthday failed\n");
+            birthday *cur, *tmp;
+            list_for_each_entry_safe(cur, tmp, &birthday_list, list) {
+                list_del(&cur->list);
+                kfree(cur);
+            }
             return -ENOMEM; // Return with out of memory error code
         }
 


### PR DESCRIPTION
## Summary
- add proper cleanup when memory allocation fails during birthday list initialization

## Testing
- `make` *(fails: `/lib/modules/6.12.13/build: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_6843dede150483248c58d7f8d33903fa