### PR TITLE
Fix timer cleanup

### DIFF
--- a/src/kernel_timer_module.c
+++ b/src/kernel_timer_module.c
@@ -52,7 +52,7 @@ static void __exit timer_demo_exit(void)
     printk(KERN_INFO "Removing Timer Demo Module\n");
     
     // Delete the timer
-    del_timer(&my_timer);
+    del_timer_sync(&my_timer);
 }
 
 // Register module entry and exit points


### PR DESCRIPTION
## Summary
- prevent rearming of timer in timer module exit

## Testing
- `make` *(fails: /lib/modules/6.12.13/build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6843e243e3e4832487c6921a8b302a79