### PR TITLE
Fix README clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ To begin your kernel module development journey, you'll need:
 
 2. **Clone the Repository**:
    ```bash
-   git clone <repo-url>
-   cd LinuxKernelModule
+   git clone https://github.com/Wal33D/Linux_Kernel_Module-C.git
+   cd Linux_Kernel_Module-C
    ```
 
 3. **Compile Your Module**:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To begin your kernel module development journey, you'll need:
 
 2. **Clone the Repository**:
    ```bash
-   git clone https://github.com/your-username/LinuxKernelModule.git
+   git clone <repo-url>
    cd LinuxKernelModule
    ```
 


### PR DESCRIPTION
## Summary
- update `git clone` command to use `<repo-url>` placeholder

## Testing
- `make --dry-run`
- `make clean --dry-run`

------
https://chatgpt.com/codex/tasks/task_b_6843e2491dd88324a92ee3c72cab0d4c