### PR TITLE
Remove -w from build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-KBUILD_CFLAGS += -w
+# Allow Make to emit compiler warnings by default.  Invoke 'make W=1'
+# to enable additional kernel build warnings.
+KBUILD_CFLAGS +=
 # Specify the path for the modules relative to the src/ directory
 obj-m += src/kernel_birthday_list_module.o src/kernel_timer_module.o src/kernel_workqueue_module.o
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ To begin your kernel module development journey, you'll need:
    ```bash
    make
    ```
+   For additional compiler warnings from the kernel build system, you can use:
+   ```bash
+   make W=1
+   ```
 
 4. **Insert Your Module into the Kernel**:
    Load your module into the kernel environment:


### PR DESCRIPTION
## Summary
- allow warnings from compiler rather than suppressing them
- document `make W=1` for enabling extra warnings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6843e589d5e88324b13269536bbaf28d