### PR TITLE
Add safety advice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ After loading your module, inspect its output or interaction with the system usi
 sudo rmmod your_module_name
 ```
 
+## ⚠️ Safety
+
+Loading kernel modules requires root privileges and can potentially crash or hang
+your system. Always test new modules in a virtual machine or other
+non-production environment before deploying on real hardware.
+
 ### Contributing 🤝
 
 Contributions are the cornerstone of this project's growth and success. Whether it's adding new features, fixing bugs, or improving documentation, your help is greatly appreciated.


### PR DESCRIPTION
## Summary
- mention that loading modules requires root privileges and may crash or hang the system
- recommend testing modules in a VM or non-production machine

## Testing
- `make` *(fails: `/lib/modules/6.12.13/build` no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6843e586d96c83249e3d6f6abb67429e