### PR TITLE
Add module parameters for timer and workqueue intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ After loading your module, inspect its output or interaction with the system usi
 sudo rmmod your_module_name
 ```
 
+### Example Module Usage
+
+Set the timer interval when loading `kernel_timer_module`:
+
+```bash
+sudo insmod src/kernel_timer_module.ko timer_interval=2
+```
+
+Specify the requeue interval for `kernel_workqueue_module`:
+
+```bash
+sudo insmod src/kernel_workqueue_module.ko work_interval=10
+```
+
 ## ⚠️ Safety
 
 Loading kernel modules requires root privileges and can potentially crash or hang

--- a/src/kernel_timer_module.c
+++ b/src/kernel_timer_module.c
@@ -4,8 +4,9 @@
  * License: MIT
  *
  * This module demonstrates the use of kernel timers to execute tasks periodically.
- * A kernel timer is initialized to trigger a callback function every 5 seconds,
- * which logs a message to the kernel log. This example showcases the mechanism for
+ * A kernel timer is initialized to trigger a callback function periodically.
+ * The interval can be set when the module is loaded using the `timer_interval`
+ * parameter. Each expiry logs a message to the kernel log. This example showcases the mechanism for
  * scheduling and handling timed events within the Linux kernel.
  *
  * Usage:
@@ -21,7 +22,10 @@
 
 #define DRIVER_AUTHOR "Wal33D"
 #define DRIVER_DESC "Kernel Timer Demo Module"
-#define TIMER_INTERVAL HZ*5 // 5 seconds; HZ is number of ticks per second
+
+static unsigned int timer_interval = 5; // Interval in seconds
+module_param(timer_interval, uint, 0644);
+MODULE_PARM_DESC(timer_interval, "Timer interval in seconds");
 
 static struct timer_list my_timer;
 
@@ -30,8 +34,8 @@ static void timer_callback(struct timer_list *timer)
 {
     printk(KERN_INFO "Timer expired and callback function is called!\n");
     
-    // Reschedule the timer for another TIMER_INTERVAL seconds later
-    mod_timer(timer, jiffies + TIMER_INTERVAL);
+    // Reschedule the timer for another timer_interval seconds later
+    mod_timer(timer, jiffies + timer_interval * HZ);
 }
 
 static int __init timer_demo_init(void)
@@ -42,7 +46,7 @@ static int __init timer_demo_init(void)
     timer_setup(&my_timer, timer_callback, 0);
     
     // Schedule the timer for the first time
-    mod_timer(&my_timer, jiffies + TIMER_INTERVAL);
+    mod_timer(&my_timer, jiffies + timer_interval * HZ);
     
     return 0; // Module successfully loaded
 }

--- a/src/kernel_workqueue_module.c
+++ b/src/kernel_workqueue_module.c
@@ -5,7 +5,8 @@
  *
  * This module illustrates the use of kernel workqueues to manage deferred tasks.
  * It initializes a workqueue and schedules a work item that periodically logs a
- * message to the kernel log. Workqueues are useful for offloading tasks that should
+ * message to the kernel log. The requeue interval can be set at load time using
+ * the `work_interval` parameter. Workqueues are useful for offloading tasks that should
  * not run in the interrupt context, demonstrating an important asynchronous execution
  * mechanism in the Linux kernel.
  *
@@ -24,15 +25,20 @@
 #define DRIVER_AUTHOR "Wal33D"
 #define DRIVER_DESC "Kernel Workqueue Demo Module"
 
+static unsigned int work_interval = 5; // Interval in seconds
+module_param(work_interval, uint, 0644);
+MODULE_PARM_DESC(work_interval, "Work item requeue interval in seconds");
+
 static struct workqueue_struct *example_wq;
-static struct work_struct *example_work;
+static struct delayed_work *example_work;
 
 static void example_work_func(struct work_struct *work)
 {
+    (void)work; // Unused parameter
     printk(KERN_INFO "Workqueue function is executed!\n");
-    // Reschedule the work (simulate periodic work)
+    // Reschedule the work after the specified interval
     if (example_wq)
-        queue_work(example_wq, example_work);
+        queue_delayed_work(example_wq, example_work, work_interval * HZ);
 }
 
 static int __init workqueue_demo_init(void)
@@ -45,15 +51,15 @@ static int __init workqueue_demo_init(void)
         return -ENOMEM;
 
     // Allocate work
-    example_work = kmalloc(sizeof(struct work_struct), GFP_KERNEL);
+    example_work = kmalloc(sizeof(struct delayed_work), GFP_KERNEL);
     if (!example_work) {
         destroy_workqueue(example_wq);
         return -ENOMEM;
     }
 
     // Initialize and enqueue work
-    INIT_WORK(example_work, example_work_func);
-    queue_work(example_wq, example_work);
+    INIT_DELAYED_WORK(example_work, example_work_func);
+    queue_delayed_work(example_wq, example_work, work_interval * HZ);
 
     return 0;
 }
@@ -64,7 +70,7 @@ static void __exit workqueue_demo_exit(void)
 
     // Cancel and flush work
     if (example_work) {
-        cancel_work_sync(example_work);
+        cancel_delayed_work_sync(example_work);
         kfree(example_work);
     }
 


### PR DESCRIPTION
## Summary
- add `timer_interval` parameter to `kernel_timer_module`
- add `work_interval` parameter to `kernel_workqueue_module`
- document how to pass module parameters in README

## Testing
- `apt-get update`
- `apt-get install -y linux-headers-$(uname -r)` *(fails: Unable to locate package)*
- `make` *(fails: /lib/modules/6.12.13/build: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6843e604a8648324a4d257918485bdd6