### PR TITLE
Add build folder and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@
 Module.symvers
 modules.order
 .tmp_versions/
+
+# Local build output
+build/
+
+# Test binaries
+tests/*.o
+tests/*.ko
+tests/*.out

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,24 @@ KBUILD_CFLAGS +=
 # Specify the path for the modules relative to the src/ directory
 obj-m += src/kernel_birthday_list_module.o src/kernel_timer_module.o src/kernel_workqueue_module.o
 
-# Default target to compile the kernel modules
+# Directory to place built kernel object files
+BUILD_DIR ?= build
+
+# Module names without extension for convenience
+MODULES := kernel_birthday_list_module kernel_timer_module kernel_workqueue_module
+
+# Default target to compile the kernel modules and place output in $(BUILD_DIR)
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	mkdir -p $(BUILD_DIR)
+	$(MAKE) -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	@for m in $(MODULES); do \
+	if [ -f src/$$m.ko ]; then mv -f src/$$m.ko $(BUILD_DIR)/; fi; \
+	done
 
 # Target to clean up build artifacts
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	        make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	        rm -rf $(BUILD_DIR)
 
 # Targets to unload the kernel modules
 unload_birthday_list:
@@ -24,13 +35,13 @@ unload_workqueue:
 
 # Targets to load the kernel modules. Adjust the path for the ko files.
 load_birthday_list:
-	sudo insmod src/kernel_birthday_list_module.ko
+	        sudo insmod $(BUILD_DIR)/kernel_birthday_list_module.ko
 
 load_timer:
-	sudo insmod src/kernel_timer_module.ko
+	        sudo insmod $(BUILD_DIR)/kernel_timer_module.ko
 
 load_workqueue:
-	sudo insmod src/kernel_workqueue_module.ko
+	        sudo insmod $(BUILD_DIR)/kernel_workqueue_module.ko
 
 # Target to clear the kernel log buffer
 clear:

--- a/README.md
+++ b/README.md
@@ -45,16 +45,23 @@ To begin your kernel module development journey, you'll need:
    ```bash
    make
    ```
+   This places the resulting `.ko` files in the `build/` directory.
    For additional compiler warnings from the kernel build system, you can use:
    ```bash
    make W=1
    ```
 
 4. **Insert Your Module into the Kernel**:
-   Load your module into the kernel environment:
-   ```bash
-   sudo insmod your_module_name.ko
-   ```
+    Load your module into the kernel environment:
+    ```bash
+    sudo insmod your_module_name.ko
+    ```
+
+5. **Run Tests**:
+    After building, you can execute the provided test script (requires root privileges) to automatically insert and remove the sample modules:
+    ```bash
+    sudo bash tests/module_test.sh
+    ```
 
 ### Usage Tips
 
@@ -68,13 +75,13 @@ sudo rmmod your_module_name
 Set the timer interval when loading `kernel_timer_module`:
 
 ```bash
-sudo insmod src/kernel_timer_module.ko timer_interval=2
+sudo insmod build/kernel_timer_module.ko timer_interval=2
 ```
 
 Specify the requeue interval for `kernel_workqueue_module`:
 
 ```bash
-sudo insmod src/kernel_workqueue_module.ko work_interval=10
+sudo insmod build/kernel_workqueue_module.ko work_interval=10
 ```
 
 ## ⚠️ Safety

--- a/tests/module_test.sh
+++ b/tests/module_test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+BUILD_DIR="$(dirname "$0")/../build"
+MODULES=(kernel_birthday_list_module kernel_timer_module kernel_workqueue_module)
+
+for mod in "${MODULES[@]}"; do
+    mod_ko="$BUILD_DIR/$mod.ko"
+    if [ ! -f "$mod_ko" ]; then
+        echo "$mod_ko not found. Run 'make' first." >&2
+        exit 1
+    fi
+    echo "Inserting $mod_ko"
+    sudo insmod "$mod_ko"
+    echo "Removing $mod"
+    sudo rmmod "$mod"
+    echo
+done


### PR DESCRIPTION
## Summary
- put built kernel objects in a new `build/` directory
- ignore build output and test binaries
- add a simple script in `tests/` for inserting/removing modules
- describe the new build directory and test script in the README

## Testing
- `shellcheck tests/module_test.sh`
- `make` *(fails: `/lib/modules/6.12.13/build: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_6843e7db4cb88324b2f90a026da85662